### PR TITLE
run tests with as-pect

### DIFF
--- a/as-pect.config.js
+++ b/as-pect.config.js
@@ -1,0 +1,73 @@
+module.exports = {
+	/**
+	 * A set of globs passed to the glob package that qualify typescript files for testing.
+	 */
+	include: ['src/as/**/*.spec.ts'],
+	/**
+	 * A set of globs passed to the glob package that qualify files to be added to each test.
+	 */
+	add: ['src/as/**/*.include.ts'],
+	/**
+	 * All the compiler flags needed for this test suite. Make sure that a binary file is output.
+	 */
+	flags: {
+		'--validate': [],
+		'--debug': [],
+		/** This is required. Do not change this. The filename is ignored, but required by the compiler. */
+		'--binaryFile': ['output.wasm'],
+		/** To enable wat file output, use the following flag. The filename is ignored, but required by the compiler. */
+		// "--textFile": ["output.wat"],
+		/** To select an appropriate runtime, use the --runtime compiler flag. */
+		'--runtime': ['full'], // Acceptable values are: full, half, stub (arena), and none
+	},
+	/**
+	 * A set of regexp that will disclude source files from testing.
+	 */
+	disclude: [/node_modules/],
+	/**
+	 * Add your required AssemblyScript imports here.
+	 */
+	imports: {},
+	/**
+	 * All performance statistics reporting can be configured here.
+	 */
+	performance: {
+		/** Enable performance statistics gathering for every test. */
+		enabled: false,
+		/** Set the maximum number of samples to run for every test. */
+		maxSamples: 10000,
+		/** Set the maximum test run time in milliseconds for every test. */
+		maxTestRunTime: 2000,
+		/** Report the median time in the default reporter for every test. */
+		reportMedian: true,
+		/** Report the average time in milliseconds for every test. */
+		reportAverage: true,
+		/** Report the standard deviation for every test. */
+		reportStandardDeviation: false,
+		/** Report the maximum run time in milliseconds for every test. */
+		reportMax: false,
+		/** Report the minimum run time in milliseconds for every test. */
+		reportMin: false,
+	},
+	/**
+	 * Add a custom reporter here if you want one. The following example is in typescript.
+	 *
+	 * @example
+	 * import { TestReporter, TestGroup, TestResult, TestContext } from "as-pect";
+	 *
+	 * export class CustomReporter extends TestReporter {
+	 *   // implement each abstract method here
+	 *   public abstract onStart(suite: TestContext): void;
+	 *   public abstract onGroupStart(group: TestGroup): void;
+	 *   public abstract onGroupFinish(group: TestGroup): void;
+	 *   public abstract onTestStart(group: TestGroup, result: TestResult): void;
+	 *   public abstract onTestFinish(group: TestGroup, result: TestResult): void;
+	 *   public abstract onFinish(suite: TestContext): void;
+	 * }
+	 */
+	// reporter: new CustomReporter(),
+	/**
+	 * Specify if the binary wasm file should be written to the file system.
+	 */
+	outputBinary: false,
+}

--- a/assembly/__tests__/as-pect.d.ts
+++ b/assembly/__tests__/as-pect.d.ts
@@ -1,0 +1,515 @@
+/**
+ * This function creates a test group in the test loader.
+ *
+ * @param {string} description  - This is the name of the test group.
+ * @param {() => void} callback - A function that contains all of the closures for this test group.
+ *
+ * @example
+ * describe("my test suite", (): void => {
+ *   // put your tests here
+ * });
+ */
+declare function describe(description: string, callback: () => void): void;
+
+/**
+ * This function creates a test inside the given test group. It must be placed inside a describe
+ * block.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ *
+ * @example
+ * describe("the meaning of life", (): void => {
+ *   it("should be 42", (): void => {
+ *     // put your expectations here
+ *     expect<i32>(29 + 13).toBe(42);
+ *   });
+ * });
+ */
+declare function it(description: string, callback: () => void): void;
+
+/**
+ * A test that does not run, and is longhand equivalent to using todo function without a
+ * callback. This test does not get run and is reported like a todo.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ */
+declare function xit(description: string, callback: () => void): void;
+
+/**
+ * A test that does not run, and is longhand equivalent to using todo function without a
+ * callback. This test does not get run and is reported like a todo.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ */
+declare function xtest(description: string, callback: () => void): void;
+
+/**
+ * This function creates a test inside the given test group. It must be placed inside a describe
+ * block.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ *
+ * @example
+ * describe("the meaning of life", (): void => {
+ *   test("the value should be 42", (): void => {
+ *     // put your expectations here
+ *     expect<i32>(29 + 13).toBe(42);
+ *   });
+ * });
+ */
+declare function test(description: string, callback: () => void): void;
+
+/**
+ * This function creates a test that is expected to fail. This is useful to verify if a given
+ * behavior is expected to throw.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ * @param {string?} message - A message that describes why the test should fail.
+ * @example
+ * describe("the meaning of life", (): void => {
+  *   throws("the value should be 42", (): void => {
+  *     // put your expectations here
+  *     expect<i32>(29 + 13).toBe(42);
+  *   });
+  * });
+  */
+ declare function throws(description: string, callback: () => void, message?: string): void;
+
+/**
+ * This function creates a callback that is called before each individual test is run in this test
+ * group.
+ *
+ * @param {function} callback - The function to be run before each test in the current test group.
+ *
+ * @example
+ * // create a global
+ * var cat: Cat = new Cat();
+ *
+ * describe("cats", (): void => {
+ *   beforeEach((): void => {
+ *     cat.meow(1); // meow once per test
+ *   });
+ * });
+ */
+declare function beforeEach(callback: () => void): void;
+
+/**
+ * This function creates a callback that is called before the whole test group is run, and only
+ * once.
+ *
+ * @param {function} callback - The function to be run before each test in the current test group.
+ *
+ * @example
+ * // create a global
+ * var dog: Dog = null;
+ * describe("dogs", (): void => {
+ *   beforeAll((): void => {
+ *     dog = new Dog(); // create a single dog once before the tests start
+ *   });
+ * });
+ */
+declare function beforeAll(callback: () => void): void;
+
+/**
+ * This function creates a callback that is called after each individual test is run in this test
+ * group.
+ *
+ * @param {function} callback - The function to be run after each test in the current test group.
+ *
+ * @example
+ * // create a global
+ * var cat: Cat = new Cat();
+ *
+ * describe("cats", (): void => {
+ *   afterEach((): void => {
+ *     cat.sleep(12); // cats sleep a lot
+ *   });
+ * });
+ */
+declare function afterEach(callback: () => void): void;
+
+/**
+ * This function creates a callback that is called after the whole test group is run, and only
+ * once.
+ *
+ * @param {function} callback - The function to be run after each test in the current test group.
+ *
+ * @example
+ * // create a global
+ * var dog: Dog = null;
+ * describe("dogs", (): void => {
+ *   afterAll((): void => {
+ *     memory.free(changetype<usize>(dog)); // free some memory
+ *   });
+ * });
+ */
+declare function afterAll(callback: () => void): void;
+
+/**
+ * Describes a value and returns an expectation to test the value.
+ *
+ * @type {T} - The test's type
+ * @param {T} actual - The value being tested.
+ *
+ * @example
+ * expect<i32>(42).not.toBe(-1, "42 should not be -1");
+ * expect<i32>(19 + 23).toBe(42, "19 + 23 should equal 42");
+ */
+declare function expect<T>(actual: T | null): Expectation<T>;
+
+/**
+ * Describes a function and returns an expectation to test the function.
+ *
+ * @param {() => void} callback - The callback being tested.
+ *
+ * @example
+ * expectFn((): void => unreachable()).toThrow("unreachables do not throw");
+ * expectFn((): void => {
+ *   cat.meow();
+ * }).not.toThrow("Uhoh, cats can't meow!");;
+ */
+declare function expectFn(cb: () => void): Expectation<() => void>;
+
+/**
+ * Describes a test that needs to be written.
+ *
+ * @param {string} description - The description of the test that needs to be written.
+ */
+declare function todo(description: string): void;
+
+/**
+ * Logs a single value to the logger, and is stringified. It works for references, values, and
+ * strings.
+ *
+ * @type {T} - The type to be logged.
+ * @param {T | null} value - The value to be logged.
+ * @example
+ * log<string>("This is a logged value.");
+ * log<i32>(42);
+ * log<Vec3>(new Vec(1, 2, 3));
+ * log<Vec3>(null);
+ */
+declare function log<T>(value: T | null): void;
+
+/**
+* An expectation for a value.
+*/
+declare class Expectation<T> {
+
+  /**
+   * Create a new expectation.
+   *
+   * @param {T | null} actual - The actual value of the expectation.
+   */
+  constructor(actual: T | null);
+
+  /**
+   * This expectation performs a strict equality on value types and reference types.
+   *
+   * @param {T | null} expected - The value to be compared.
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<i32>(42).not.toBe(-1, "42 should not be -1");
+   * expect<i32>(19 + 23).toBe(42, "19 + 23 should equal 42");
+   */
+  toBe(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation performs a strict equality on value types and performs a memcompare on
+   * reference types. If the reference type `T` has reference types as properties, the comparison does
+   * not perform property traversal. It will only compare the pointer values in the memory block, and
+   * only compare `offsetof<T>()` bytes, regardless of the allocated block size.
+   *
+   * @param {T | null} expected - The value to be compared.
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<Vec3>(new Vec3(1, 2, 3)).toStrictEqual(new Vec(1, 2, 3), "Vectors of the same shape should be equal");
+   */
+  toStrictEqual(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation performs a strict memory block equality based on the allocated block sizes.
+   *
+   * @param {T | null} expected - The value to be compared.
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<Vec3>(new Vec3(1, 2, 3)).toBlockEqual(new Vec(1, 2, 3), "Vectors of the same shape should be equal");
+   */
+  toBlockEqual(expected: T | null, message?: string): void;
+
+  /**
+   * If the value is callable, it calls the function, and fails the expectation if it throws, or hits
+   * an unreachable().
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expectFn((): void => unreachable()).toThrow("unreachable() should throw.");
+   * expectFn((): void => {
+   *   cat.sleep(100); // cats can sleep quite a lot
+   * }).not.toThrow("cats should sleep, not throw");
+   */
+  toThrow(message?: string): void;
+
+  /**
+   * This expecation asserts that the value is truthy, like in javascript. If the value is a string,
+   * then strings of length 0 are not truthy.
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<bool>(true).toBeTruthy("true is truthy.");
+   * expect<i32>(1).toBeTruthy("numeric values that are not 0 are truthy.");
+   * expect<Vec3>(new Vec3(1, 2, 3)).toBeTruthy("reference types that aren't null are truthy.");
+   * expect<bool>(false).not.toBeTruthy("false is not truthy.");
+   * expect<i32>(0).not.toBeTruthy("0 is not truthy.");
+   * expect<Vec3>(null).not.toBeTruthy("null is not truthy.");
+   */
+  toBeTruthy(message?: string): void;
+
+  /**
+   * This expectation tests the value to see if it is null. If the value is a value type, it is
+   * never null. If the value is a reference type, it performs a strict null comparison.
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<i32>(0).not.toBeNull("numbers are never null");
+   * expect<Vec3>(null).toBeNull("null reference types are null.");
+   */
+  toBeNull(message?: string): void;
+
+  /**
+   * This expecation assert that the value is falsy, like in javascript. If the value is a string,
+   * then strings of length 0 are falsy.
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<bool>(false).toBeFalsy("false is falsy.");
+   * expect<i32>(0).toBeFalsy("0 is falsy.");
+   * expect<Vec3>(null).toBeFalsy("null is falsy.");
+   * expect<bool>(true).not.toBeFalsy("true is not falsy.");
+   * expect<i32>(1).not.toBeFalsy("numeric values that are not 0 are not falsy.");
+   * expect<Vec3>(new Vec3(1, 2, 3)).not.toBeFalsy("reference types that aren't null are not falsy.");
+   */
+  toBeFalsy(message?: string): void;
+
+  /**
+   * This expectation asserts that the value is greater than the expected value. Since operators can
+   * be overloaded in assemblyscript, it's possible for this to work on reference types.
+   *
+   * @param {T | null} expected - The expected value that the actual value should be greater than.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   * expect<i32>(10).toBeGreaterThan(4);
+   * expect<i32>(12).not.toBeGreaterThan(42);
+   */
+  toBeGreaterThan(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is less than the expected value. Since operators can
+   * be overloaded in assemblyscript, it's possible for this to work on reference types.
+   *
+   * @param {T | null} value - The expected value that the actual value should be less than.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   * expect<i32>(10).not.toBeLessThan(4);
+   * expect<i32>(12).toBeLessThan(42);
+   */
+  toBeLessThan(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is greater than or equal to the expected value. Since
+   * operators can be overloaded in assemblyscript, it's possible for this to work on reference
+   * types.
+   *
+   * @param {T | null} value - The expected value that the actual value should be greater than or
+   * equal to.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   * expect<i32>(42).toBeGreaterThanOrEqualTo(42);
+   * expect<i32>(10).toBeGreaterThanOrEqualTo(4);
+   * expect<i32>(12).not.toBeGreaterThanOrEqualTo(42);
+   */
+  toBeGreaterThanOrEqualTo(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is less than or equal to the expected value. Since
+   * operators can be overloaded in assemblyscript, it's possible for this to work on reference
+   * types.
+   *
+   * @param {T | null} value - The expected value that the actual value should be less than or equal
+   * to.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   * expect<i32>(42).toBeLessThanOrEqualTo(42);
+   * expect<i32>(10).not.toBeLessThanOrEqualTo(4);
+   * expect<i32>(12).toBeLessThanOrEqualTo(42);
+   */
+  toBeLessThanOrEqualTo(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is close to another value. Both numbers must be finite,
+   * and T must extend f64 or f32.
+   *
+   * @param {T extends f64 | f32} value - The expected value to be close to.
+   * @param {i32} decimalPlaces - The number of decimal places used to calculate epsilon. Default is
+   * 2.
+   * @param {string} message - The optional message that describes this expectation.
+   */
+  toBeCloseTo(expected: T, decimalPlaces?: number, message?: string): void;
+
+  /**
+   * This function asserts the float type value is NaN.
+   *
+   * @param {string} message - The optional message the describes this expectation.
+   * @example
+   * expect<f64>(NaN).toBeNaN();
+   * expect<f32>(42).not.toBeNaN();
+   */
+  toBeNaN(message?: string): void;
+
+  /**
+   * This function asserts a float is finite.
+   *
+   * @param {string} message - The optional message the describes this expectation.
+   * @example
+   * expect<f32>(42).toBeFinite();
+   * expect<f64>(Infinity).not.toBeFinite();
+   */
+  toBeFinite(message?: string): void;
+
+  /**
+   * This method asserts the item has the expected length.
+   *
+   * @param {i32} expected - The expected length.
+   * @param {string} message - The optional message the describes this expectation.
+   */
+  toHaveLength(expected: i32, message?: string): void;
+
+  /**
+   * This method asserts that a given T that extends Array<U> has a value/reference included.
+   *
+   * @param {i32} expected - The expected item to be included in the Array.
+   * @param {string} message - The optional message the describes this expectation.
+   */
+  toInclude<U>(expected: U, message?: string): void;
+
+
+  /**
+   * This method asserts that a given T that extends Array<U> has a value/reference included and
+   * compared via memory.compare().
+   *
+   * @param {i32} expected - The expected item to be included in the Array.
+   * @param {string} message - The optional message the describes this expectation.
+   */
+  toIncludeEqual<U>(expected: U, message?: string): void;
+
+  /**
+   * This computed property is chainable, and negates the existing expectation. It returns itself.
+   *
+   * @param {U} expected - The expected item.
+   * @param {string} message - The optional message the describes this expectation.
+   * @type {Expectation<T>}
+   */
+  not: Expectation<T>;
+
+  /**
+   * The actual value of the expectation.
+   */
+  actual: T | null;
+  private _not: boolean;
+}
+
+/**
+ * This is called to stop the debugger.  e.g. `node --inspect-brk asp`.
+ */
+declare function debug(): void;
+
+/**
+ * This function call enables performance statistics gathering for the following test.
+ *
+ * @param {bool} enabled - The bool to indicate if performance statistics should be gathered.
+ */
+declare function performanceEnabled(enabled: bool): void;
+
+/**
+ * This function call sets the maximum number of samples to complete the following test.
+ *
+ * @param {f64} count - The maximum number of samples required.
+ */
+declare function maxSamples(count: f64): void;
+
+/**
+ * This function call sets the number of decimal places to round to for the following test.
+ *
+ * @param {i32} deicmalPlaces - The number of decimal places to round to
+ */
+declare function roundDecimalPlaces(count: i32): void;
+
+/**
+ * This function call will set the maximum amount of time that should pass before it can stop
+ * gathering samples for the following test.
+ *
+ * @param {f64} time - The ammount of time in milliseconds.
+ */
+declare function maxTestRunTime(time: f64): void;
+
+/**
+ * This function call enables gathering the average/mean run time of each sample for the following
+ * test.
+ *
+ * @param {bool} enabled - The bool to indicate if the average/mean should be gathered.
+ */
+declare function reportAverage(enabled: bool): void;
+
+/**
+ * This function call enables gathering the median run time of each sample for the following test.
+ *
+ * @param {bool} enabled - The bool to indicate if the median should be gathered.
+ */
+declare function reportMedian(value: bool): void;
+
+/**
+ * This function call enables gathering the standard deviation of the run times of the samples
+ * collected for the following test.
+ *
+ * @param {bool} enabled - The bool to indicate if the standard deviation should be gathered.
+ */
+declare function reportStdDev(value: bool): void;
+
+/**
+ * This function call enables gathering the largest run time of the samples collected for the
+ * following test.
+ *
+ * @param {bool} enabled - The bool to indicate if the max should be gathered.
+ */
+declare function reportMax(value: bool): void;
+
+/**
+ * This function call enables gathering the smallest run time of the samples collected for the
+ * following test.
+ *
+ * @param {bool} enabled - The bool to indicate if the min should be gathered.
+ */
+declare function reportMin(value: bool): void;
+
+/**
+ * This function call enables gathering the varaince of the samples collected for the following test.
+ *
+ * @param {bool} enabled - The bool to indicate if the variance should be calculated.
+ */
+declare function reportVariance(value: bool): void;

--- a/assembly/__tests__/example.spec.ts
+++ b/assembly/__tests__/example.spec.ts
@@ -1,0 +1,5 @@
+describe("example", (): void => {
+  it("should be truthy", (): void => {
+    expect<i32>(19 + 23).toBe(42, "42 is the meaning of life.");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,7 @@
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
-      "dev": true
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@types/node": {
       "version": "12.0.2",
@@ -21,6 +20,14 @@
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -59,6 +66,11 @@
       "integrity": "sha1-7klza2ObTxCLbp5ibG2pkwa0FpI=",
       "dev": true
     },
+    "arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -82,6 +94,33 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "as-pect": {
+      "version": "github:jtenner/as-pect#a6683906f5239641d8c04614f923c2281cd11849",
+      "from": "github:jtenner/as-pect#a6683906f5239641d8c04614f923c2281cd11849",
+      "requires": {
+        "assemblyscript": "github:AssemblyScript/assemblyscript#dev",
+        "chalk": "^2.4.2",
+        "csv-stringify": "^5.3.0",
+        "glob": "^7.1.4",
+        "mathjs": "^5.10.3",
+        "ts-node": "^8.2.0",
+        "yargs-parser": "^13.1.0"
+      },
+      "dependencies": {
+        "assemblyscript": {
+          "version": "github:AssemblyScript/assemblyscript#5b41c1f2fabac0f42b5b7cd0b9cfea6339eeaff5",
+          "from": "github:AssemblyScript/assemblyscript#dev",
+          "requires": {
+            "@protobufjs/utf8": "^1.1.0",
+            "binaryen": "84.0.0-nightly.20190522",
+            "glob": "^7.1.3",
+            "long": "^4.0.0",
+            "opencollective-postinstall": "^2.0.0",
+            "source-map-support": "^0.5.11"
+          }
+        }
+      }
     },
     "assemblyscript": {
       "version": "github:trusktr/assemblyscript#f03d77bbed6317ee8cd672215b855ebcf622c0a7",
@@ -117,8 +156,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -205,14 +243,12 @@
     "binaryen": {
       "version": "84.0.0-nightly.20190522",
       "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-84.0.0-nightly.20190522.tgz",
-      "integrity": "sha512-bxSPi3MOkFmK5W6VIlqxnOc1nYzpUCzT/tHz3C7sgbz7jTR2lOBlZnKStTJlBt018xeZK9/JpK/jXdduH7eQFg==",
-      "dev": true
+      "integrity": "sha512-bxSPi3MOkFmK5W6VIlqxnOc1nYzpUCzT/tHz3C7sgbz7jTR2lOBlZnKStTJlBt018xeZK9/JpK/jXdduH7eQFg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -250,8 +286,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -268,6 +303,21 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chokidar": {
@@ -323,11 +373,29 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
     "colors": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
       "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
+    },
+    "complex.js": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.11.tgz",
+      "integrity": "sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -338,8 +406,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "connect": {
       "version": "3.7.0",
@@ -375,6 +442,14 @@
         "vary": "^1"
       }
     },
+    "csv-stringify": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.3.0.tgz",
+      "integrity": "sha512-VMYPbE8zWz475smwqb9VbX9cj0y4J0PBl59UdcqzLkzXHZZ8dh4Rmbb0ZywsWEtUml4A96Hn7Q5MW9ppVghYzg==",
+      "requires": {
+        "lodash.get": "~4.4.2"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -383,6 +458,16 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -443,6 +528,11 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "diff": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -466,6 +556,16 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
+    },
+    "escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "etag": {
       "version": "1.8.1",
@@ -662,6 +762,11 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
+    "fraction.js": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.12.tgz",
+      "integrity": "sha512-8Z1K0VTG4hzYY7kA/1sj4/r1/RWLBD3xwReT/RCrUCbzPszjNQCCsy3ktkU/eaEqX3MYa4pY37a52eiBlPMlhA=="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -686,8 +791,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.9",
@@ -1247,7 +1351,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1283,6 +1386,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-value": {
       "version": "1.0.0",
@@ -1351,7 +1459,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1360,8 +1467,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -1511,6 +1617,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -1538,11 +1649,20 @@
         "serve-index": "^1.9.1"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
     },
     "map-cache": {
       "version": "0.2.2",
@@ -1563,6 +1683,21 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "mathjs": {
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.10.3.tgz",
+      "integrity": "sha512-ySjg30BC3dYjQm73ILZtwcWzFJde0VU6otkXW/57IjjuYRa3Qaf0Kb8pydEuBZYtqW2OxreAtsricrAmOj3jIw==",
+      "requires": {
+        "complex.js": "2.0.11",
+        "decimal.js": "10.2.0",
+        "escape-latex": "1.2.0",
+        "fraction.js": "4.0.12",
+        "javascript-natural-sort": "0.7.1",
+        "seed-random": "2.2.0",
+        "tiny-emitter": "2.1.0",
+        "typed-function": "1.1.0"
       }
     },
     "micromatch": {
@@ -1611,7 +1746,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1768,7 +1902,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1776,8 +1909,7 @@
     "opencollective-postinstall": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
-      "dev": true
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
     },
     "opn": {
       "version": "6.0.0",
@@ -1809,8 +1941,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -1925,6 +2056,11 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "seed-random": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
+      "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
     },
     "send": {
       "version": "0.17.1",
@@ -2135,8 +2271,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -2155,7 +2290,6 @@
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
       "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -2230,11 +2364,24 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -2283,6 +2430,23 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
+    },
+    "ts-node": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.2.0.tgz",
+      "integrity": "sha512-m8XQwUurkbYqXrKqr3WHCW310utRNvV5OnRVeISeea7LoCWVcdfeB/Ntl8JYWFh+WRoUAdBgESrzKochQt7sMw==",
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      }
+    },
+    "typed-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-1.1.0.tgz",
+      "integrity": "sha512-TuQzwiT4DDg19beHam3E66oRXhyqlyfgjHB/5fcvsRXbfmWPJfto9B4a0TBdTrQAPGlGmXh/k7iUI+WsObgORA=="
     },
     "typescript": {
       "version": "3.4.5",
@@ -2438,8 +2602,21 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yargs-parser": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
+      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"typescript": "^3.4.5"
 	},
 	"dependencies": {
-		"@types/node": "^12.0.2"
+		"@types/node": "^12.0.2",
+		"as-pect": "github:jtenner/as-pect#a6683906f5239641d8c04614f923c2281cd11849"
 	}
 }

--- a/src/as/__tests__/as-pect.d.ts
+++ b/src/as/__tests__/as-pect.d.ts
@@ -1,0 +1,483 @@
+/**
+ * This function creates a test group in the test loader.
+ *
+ * @param {string} description  - This is the name of the test group.
+ * @param {() => void} callback - A function that contains all of the closures for this test group.
+ *
+ * @example
+ * describe("my test suite", (): void => {
+ *   // put your tests here
+ * });
+ */
+declare function describe(description: string, callback: () => void): void;
+
+/**
+ * This function creates a test inside the given test group. It must be placed inside a describe
+ * block.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ *
+ * @example
+ * describe("the meaning of life", (): void => {
+ *   it("should be 42", (): void => {
+ *     // put your expectations here
+ *     expect<i32>(29 + 13).toBe(42);
+ *   });
+ * });
+ */
+declare function it(description: string, callback: () => void): void;
+
+/**
+ * A test that does not run, and is longhand equivalent to using todo function without a
+ * callback. This test does not get run and is reported like a todo.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ */
+declare function xit(description: string, callback: () => void): void;
+
+/**
+ * A test that does not run, and is longhand equivalent to using todo function without a
+ * callback. This test does not get run and is reported like a todo.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ */
+declare function xtest(description: string, callback: () => void): void;
+
+/**
+ * This function creates a test inside the given test group. It must be placed inside a describe
+ * block.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ *
+ * @example
+ * describe("the meaning of life", (): void => {
+ *   test("the value should be 42", (): void => {
+ *     // put your expectations here
+ *     expect<i32>(29 + 13).toBe(42);
+ *   });
+ * });
+ */
+declare function test(description: string, callback: () => void): void;
+
+/**
+ * This function creates a test that is expected to fail. This is useful to verify if a given
+ * behavior is expected to throw.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ * @param {string?} message - A message that describes why the test should fail.
+ * @example
+ * describe("the meaning of life", (): void => {
+  *   throws("the value should be 42", (): void => {
+  *     // put your expectations here
+  *     expect<i32>(29 + 13).toBe(42);
+  *   });
+  * });
+  */
+ declare function throws(description: string, callback: () => void, message?: string): void;
+
+/**
+ * This function creates a callback that is called before each individual test is run in this test
+ * group.
+ *
+ * @param {function} callback - The function to be run before each test in the current test group.
+ *
+ * @example
+ * // create a global
+ * var cat: Cat = new Cat();
+ *
+ * describe("cats", (): void => {
+ *   beforeEach((): void => {
+ *     cat.meow(1); // meow once per test
+ *   });
+ * });
+ */
+declare function beforeEach(callback: () => void): void;
+
+/**
+ * This function creates a callback that is called before the whole test group is run, and only
+ * once.
+ *
+ * @param {function} callback - The function to be run before each test in the current test group.
+ *
+ * @example
+ * // create a global
+ * var dog: Dog = null;
+ * describe("dogs", (): void => {
+ *   beforeAll((): void => {
+ *     dog = new Dog(); // create a single dog once before the tests start
+ *   });
+ * });
+ */
+declare function beforeAll(callback: () => void): void;
+
+/**
+ * This function creates a callback that is called after each individual test is run in this test
+ * group.
+ *
+ * @param {function} callback - The function to be run after each test in the current test group.
+ *
+ * @example
+ * // create a global
+ * var cat: Cat = new Cat();
+ *
+ * describe("cats", (): void => {
+ *   afterEach((): void => {
+ *     cat.sleep(12); // cats sleep a lot
+ *   });
+ * });
+ */
+declare function afterEach(callback: () => void): void;
+
+/**
+ * This function creates a callback that is called after the whole test group is run, and only
+ * once.
+ *
+ * @param {function} callback - The function to be run after each test in the current test group.
+ *
+ * @example
+ * // create a global
+ * var dog: Dog = null;
+ * describe("dogs", (): void => {
+ *   afterAll((): void => {
+ *     memory.free(changetype<usize>(dog)); // free some memory
+ *   });
+ * });
+ */
+declare function afterAll(callback: () => void): void;
+
+/**
+ * Describes a value and returns an expectation to test the value.
+ *
+ * @type {T} - The test's type
+ * @param {T} actual - The value being tested.
+ *
+ * @example
+ * expect<i32>(42).not.toBe(-1, "42 should not be -1");
+ * expect<i32>(19 + 23).toBe(42, "19 + 23 should equal 42");
+ */
+declare function expect<T>(actual: T | null): Expectation<T>;
+
+/**
+ * Describes a function and returns an expectation to test the function.
+ *
+ * @param {() => void} callback - The callback being tested.
+ *
+ * @example
+ * expectFn((): void => unreachable()).toThrow("unreachables do not throw");
+ * expectFn((): void => {
+ *   cat.meow();
+ * }).not.toThrow("Uhoh, cats can't meow!");;
+ */
+declare function expectFn(cb: () => void): Expectation<() => void>;
+
+/**
+ * Describes a test that needs to be written.
+ *
+ * @param {string} description - The description of the test that needs to be written.
+ */
+declare function todo(description: string): void;
+
+/**
+ * Logs a single value to the logger, and is stringified. It works for references, values, and
+ * strings.
+ *
+ * @type {T} - The type to be logged.
+ * @param {T | null} value - The value to be logged.
+ * @example
+ * log<string>("This is a logged value.");
+ * log<i32>(42);
+ * log<Vec3>(new Vec(1, 2, 3));
+ * log<Vec3>(null);
+ */
+declare function log<T>(value: T | null): void;
+
+/**
+* An expectation for a value.
+*/
+declare class Expectation<T> {
+
+  /**
+   * Create a new expectation.
+   *
+   * @param {T | null} actual - The actual value of the expectation.
+   */
+  constructor(actual: T | null);
+
+  /**
+   * This expectation performs a strict equality on value types and reference types.
+   *
+   * @param {T | null} expected - The value to be compared.
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<i32>(42).not.toBe(-1, "42 should not be -1");
+   * expect<i32>(19 + 23).toBe(42, "19 + 23 should equal 42");
+   */
+  toBe(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation performs a strict equality on value types and performs a memcompare on
+   * reference types. If the reference type T has reference types as properties, the comparison does
+   * not perform property traversal. It will only compare the pointer values in the memory block.
+   *
+   * @param {T | null} expected - The value to be compared.
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<Vec3>(new Vec3(1, 2, 3)).toStrictEqual(new Vec(1, 2, 3), "Vectors of the same shape should be equal");
+   */
+  toStrictEqual(expected: T | null, message?: string): void;
+
+  /**
+   * If the value is callable, it calls the function, and fails the expectation if it throws, or hits
+   * an unreachable().
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expectFn((): void => unreachable()).toThrow("unreachable() should throw.");
+   * expectFn((): void => {
+   *   cat.sleep(100); // cats can sleep quite a lot
+   * }).not.toThrow("cats should sleep, not throw");
+   */
+  toThrow(message?: string): void;
+
+  /**
+   * This expecation asserts that the value is truthy, like in javascript. If the value is a string,
+   * then strings of length 0 are not truthy.
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<bool>(true).toBeTruthy("true is truthy.");
+   * expect<i32>(1).toBeTruthy("numeric values that are not 0 are truthy.");
+   * expect<Vec3>(new Vec3(1, 2, 3)).toBeTruthy("reference types that aren't null are truthy.");
+   * expect<bool>(false).not.toBeTruthy("false is not truthy.");
+   * expect<i32>(0).not.toBeTruthy("0 is not truthy.");
+   * expect<Vec3>(null).not.toBeTruthy("null is not truthy.");
+   */
+  toBeTruthy(message?: string): void;
+
+  /**
+   * This expectation tests the value to see if it is null. If the value is a value type, it is
+   * never null. If the value is a reference type, it performs a strict null comparison.
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<i32>(0).not.toBeNull("numbers are never null");
+   * expect<Vec3>(null).toBeNull("null reference types are null.");
+   */
+  toBeNull(message?: string): void;
+
+  /**
+   * This expecation assert that the value is falsy, like in javascript. If the value is a string,
+   * then strings of length 0 are falsy.
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   * expect<bool>(false).toBeFalsy("false is falsy.");
+   * expect<i32>(0).toBeFalsy("0 is falsy.");
+   * expect<Vec3>(null).toBeFalsy("null is falsy.");
+   * expect<bool>(true).not.toBeFalsy("true is not falsy.");
+   * expect<i32>(1).not.toBeFalsy("numeric values that are not 0 are not falsy.");
+   * expect<Vec3>(new Vec3(1, 2, 3)).not.toBeFalsy("reference types that aren't null are not falsy.");
+   */
+  toBeFalsy(message?: string): void;
+
+  /**
+   * This expectation asserts that the value is greater than the expected value. Since operators can
+   * be overloaded in assemblyscript, it's possible for this to work on reference types.
+   *
+   * @param {T | null} expected - The expected value that the actual value should be greater than.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   * expect<i32>(10).toBeGreaterThan(4);
+   * expect<i32>(12).not.toBeGreaterThan(42);
+   */
+  toBeGreaterThan(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is less than the expected value. Since operators can
+   * be overloaded in assemblyscript, it's possible for this to work on reference types.
+   *
+   * @param {T | null} value - The expected value that the actual value should be less than.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   * expect<i32>(10).not.toBeLessThan(4);
+   * expect<i32>(12).toBeLessThan(42);
+   */
+  toBeLessThan(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is greater than or equal to the expected value. Since
+   * operators can be overloaded in assemblyscript, it's possible for this to work on reference
+   * types.
+   *
+   * @param {T | null} value - The expected value that the actual value should be greater than or
+   * equal to.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   * expect<i32>(42).toBeGreaterThanOrEqualTo(42);
+   * expect<i32>(10).toBeGreaterThanOrEqualTo(4);
+   * expect<i32>(12).not.toBeGreaterThanOrEqualTo(42);
+   */
+  toBeGreaterThanOrEqualTo(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is less than or equal to the expected value. Since
+   * operators can be overloaded in assemblyscript, it's possible for this to work on reference
+   * types.
+   *
+   * @param {T | null} value - The expected value that the actual value should be less than or equal
+   * to.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   * expect<i32>(42).toBeLessThanOrEqualTo(42);
+   * expect<i32>(10).not.toBeLessThanOrEqualTo(4);
+   * expect<i32>(12).toBeLessThanOrEqualTo(42);
+   */
+  toBeLessThanOrEqualTo(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is close to another value. Both numbers must be finite,
+   * and T must extend f64 or f32.
+   *
+   * @param {T extends f64 | f32} value - The expected value to be close to.
+   * @param {i32} decimalPlaces - The number of decimal places used to calculate epsilon. Default is
+   * 2.
+   * @param {string} message - The optional message that describes this expectation.
+   */
+  toBeCloseTo(expected: T, decimalPlaces?: number, message?: string): void;
+
+  /**
+   * This function asserts the float type value is NaN.
+   *
+   * @param {string} message - The optional message the describes this expectation.
+   * @example
+   * expect<f64>(NaN).toBeNaN();
+   * expect<f32>(42).not.toBeNaN();
+   */
+  toBeNaN(message?: string): void;
+
+  /**
+   * This function asserts a float is finite.
+   *
+   * @param {string} message - The optional message the describes this expectation.
+   * @example
+   * expect<f32>(42).toBeFinite();
+   * expect<f64>(Infinity).not.toBeFinite();
+   */
+  toBeFinite(message?: string): void;
+
+  /**
+   * This method asserts the item has the expected length.
+   *
+   * @param {i32} expected - The expected length.
+   * @param {string} message - The optional message the describes this expectation.
+   */
+  toHaveLength(expected: i32, message?: string): void;
+
+  /**
+   * This computed property is chainable, and negates the existing expectation. It returns itself.
+   *
+   * @type {Expectation<T>}
+   */
+  not: Expectation<T>;
+
+  /**
+   * The actual value of the expectation.
+   */
+  actual: T | null;
+  private _not: boolean;
+}
+
+/**
+ * This is called to stop the debugger.  e.g. `node --inspect-brk asp`.
+ */
+declare function debug(): void;
+
+/**
+ * This function call enables performance statistics gathering for the following test.
+ *
+ * @param {bool} enabled - The bool to indicate if performance statistics should be gathered.
+ */
+declare function performanceEnabled(enabled: bool): void;
+
+/**
+ * This function call sets the maximum number of samples to complete the following test.
+ *
+ * @param {f64} count - The maximum number of samples required.
+ */
+declare function maxSamples(count: f64): void;
+
+/**
+ * This function call sets the number of decimal places to round to for the following test.
+ *
+ * @param {i32} deicmalPlaces - The number of decimal places to round to
+ */
+declare function roundDecimalPlaces(count: i32): void;
+
+/**
+ * This function call will set the maximum amount of time that should pass before it can stop
+ * gathering samples for the following test.
+ *
+ * @param {f64} time - The ammount of time in milliseconds.
+ */
+declare function maxTestRunTime(time: f64): void;
+
+/**
+ * This function call enables gathering the average/mean run time of each sample for the following
+ * test.
+ *
+ * @param {bool} enabled - The bool to indicate if the average/mean should be gathered.
+ */
+declare function reportAverage(enabled: bool): void;
+
+/**
+ * This function call enables gathering the median run time of each sample for the following test.
+ *
+ * @param {bool} enabled - The bool to indicate if the median should be gathered.
+ */
+declare function reportMedian(value: bool): void;
+
+/**
+ * This function call enables gathering the standard deviation of the run times of the samples
+ * collected for the following test.
+ *
+ * @param {bool} enabled - The bool to indicate if the standard deviation should be gathered.
+ */
+declare function reportStdDev(value: bool): void;
+
+/**
+ * This function call enables gathering the largest run time of the samples collected for the
+ * following test.
+ *
+ * @param {bool} enabled - The bool to indicate if the max should be gathered.
+ */
+declare function reportMax(value: bool): void;
+
+/**
+ * This function call enables gathering the smallest run time of the samples collected for the
+ * following test.
+ *
+ * @param {bool} enabled - The bool to indicate if the min should be gathered.
+ */
+declare function reportMin(value: bool): void;
+
+/**
+ * This function call enables gathering the varaince of the samples collected for the following test.
+ *
+ * @param {bool} enabled - The bool to indicate if the variance should be calculated.
+ */
+declare function reportVariance(value: bool): void;

--- a/src/as/__tests__/example.spec.ts
+++ b/src/as/__tests__/example.spec.ts
@@ -1,0 +1,5 @@
+describe("example", (): void => {
+  it("should be truthy", (): void => {
+    expect<i32>(19 + 23).toBe(42, "42 is the meaning of life.");
+  });
+});

--- a/src/as/glas/Size.spec.ts
+++ b/src/as/glas/Size.spec.ts
@@ -1,0 +1,111 @@
+import {Size} from './Size'
+
+describe('Size', (): void => {
+	describe('.getClassName', (): void => {
+		test('it should return the name of the class', (): void => {
+			const s = new Size(0, 0)
+			expect<string>(s.getClassName()).toBe('Size')
+		})
+	})
+
+	describe('.toString', (): void => {
+		it('should return a string representation of the Size', (): void => {
+			const s = new Size(20.0, 30.0)
+			expect<string>(s.toString()).toBe('{W: 20.0, H: 30.0}')
+		})
+	})
+
+	describe('.getHashCode', (): void => {
+		it('should return a unique hash representation of the Size', (): void => {
+			const s = new Size(20, 30)
+			expect<u64>(s.getHashCode()).toBe(u64(15031326706302451712))
+		})
+	})
+
+	describe('.copy', (): void => {
+		it('should copy values from another Size', (): void => {
+			const s = new Size(0, 0)
+			const o = new Size(20, 30)
+			s.copy(o)
+			assertDimensions(s, 20, 30)
+		})
+	})
+
+	describe('.set', (): void => {
+		it('should set the width and height values', (): void => {
+			const s = new Size(0, 0)
+			s.set(2.4, 3.5)
+			assertDimensions(s, 2.4, 3.5)
+		})
+	})
+
+	describe('.multiply', (): void => {
+		it('should multiply the values of the Size object by another Size', (): void => {
+			const s = new Size(2, 3)
+			const o = new Size(4, 3)
+			s.multiply(o)
+			assertDimensions(s, 8, 9)
+		})
+	})
+
+	describe('.multiplyFloats', (): void => {
+		it('should multiply the values of the Size object by another Size', (): void => {
+			const s = new Size(2, 3)
+			s.multiplyFloats(4, 3)
+			assertDimensions(s, 8, 9)
+		})
+	})
+
+	describe('.equals', (): void => {
+		it('should test if this Size equals the given Size', (): void => {
+			const s = new Size(2, 3)
+			const o = new Size(2, 3)
+			expect<boolean>(s.equals(o)).toBe(true)
+		})
+	})
+
+	describe('.area', (): void => {
+		it('returns the surface area of the Size', (): void => {
+			const s = new Size(2, 3)
+			expect<f64>(s.area).toBe(6)
+		})
+	})
+
+	describe('.Zero', (): void => {
+		it('create a new Size with dimensions 0,0', (): void => {
+			const s = Size.Zero()
+			assertDimensions(s, 0, 0)
+		})
+	})
+
+	describe('.add', (): void => {
+		it('should add another Size to this Size', (): void => {
+			const s = new Size(20.1, 30.2)
+			const other = new Size(40.3, 50.4)
+			s.add(other)
+			assertDimensions(s, 60.4, 80.6)
+		})
+	})
+
+	describe('.subtract', (): void => {
+		it('should subtract another Size from this Size', (): void => {
+			const s = new Size(10, 20)
+			const other = new Size(5, 10)
+			s.subtract(other)
+			assertDimensions(s, 5, 10)
+		})
+	})
+
+	describe('.lerp', (): void => {
+		it('should subtract another Size from this Size', (): void => {
+			const s = new Size(0, 0)
+			s.lerp(Size.Zero(), new Size(100, 200), 0.345)
+			assertDimensions(s, 34.5, 69)
+		})
+	})
+})
+
+function assertDimensions(s: Size, width: f64, height: f64): void {
+	expect<f64>(s.width).toBe(width)
+	expect<f64>(s.height).toBe(height)
+}

--- a/src/as/glas/Size.ts
+++ b/src/as/glas/Size.ts
@@ -52,8 +52,8 @@ export class Size {
 	getHashCode(): u64 {
 		// TODO original implementation doesn't work, bitwise-xor not allowed on
 		// f64 types at the moment?
-		let hash = reinterpret<u64>(this.width) || 0
-		hash = (hash * 397) ^ (reinterpret<u64>(this.height) || 0)
+		let hash = reinterpret<u64>(this.width)
+		hash = (hash * 397) ^ reinterpret<u64>(this.height)
 		return hash
 
 		// return this.toString()
@@ -63,7 +63,7 @@ export class Size {
 	 * Updates the current size from the given one.
 	 * @param src the given size
 	 */
-	copyFrom(src: Size): this {
+	copy(src: Size): this {
 		this.width = src.width
 		this.height = src.height
 		return this
@@ -117,9 +117,9 @@ export class Size {
 	}
 
 	/**
-	 * The surface of the Size : width * height (float).
+	 * The surface area of the Size : width * height (float).
 	 */
-	get surface(): f64 {
+	get area(): f64 {
 		return this.width * this.height
 	}
 
@@ -168,3 +168,6 @@ export class Size {
 		)
 	}
 }
+
+// default exports not yet supported
+// export default Size

--- a/src/as/glas/index.ts
+++ b/src/as/glas/index.ts
@@ -1,82 +1,20 @@
 // The entry file of the WebAssembly module.
 
-import {Size} from './Size'
-
 // this doesn't work, see https://github.com/AssemblyScript/assemblyscript/issues/618
 // import {dtoa} from '../../../node_modules/assemblyscript/std/assembly/util/number'
 // import {dtoa} from 'util/number'
 // dtoa(123.4)
 
-function testSize(): boolean {
-	let s = new Size(20, 30)
-	const other = new Size(40, 50)
-
-	assert(s.getClassName() == 'Size', 'Size class name is not Size')
-
-	assert(s.toString() == '{W: 20.0, H: 30.0}', 'toString should be "{W: 20.0, H: 30.0}". Got: "' + s.toString() + '"')
-
-	const hash = s.getHashCode()
-	assert(
-		hash == u64(15031326706302451712),
-		'getHashCode value was ' + hash.toString() + '. Expected 15031326706302451712'
-	)
-
+function testSize(): void {
 	// FIXME this one doesn't work, see
 	// https://github.com/AssemblyScript/assemblyscript/issues/623
 	//
+	// let s = new Size(20, 30)
+	// const other = new Size(40, 50)
 	// s = s.addBroken(other)
 	// assert(s.width == 60, 's.width is not 60, got ' + s.width.toString())
 	// assert(s.height == 80, 's.height is not 80, got ' + s.height.toString())
 	// assertDimensions(s, 60, 80)
-
-	other.set(1, 2)
-	s.copyFrom(other)
-	assertDimensions(s, 1, 2)
-
-	other.set(3.45, 74.32)
-	s.set(other.width, other.height)
-	assertDimensions(s, 3.45, 74.32)
-
-	other.set(2, 3)
-	s.set(3, 4)
-	s.multiply(other)
-	assertDimensions(s, 6, 12)
-
-	s.multiplyFloats(3, 2)
-	assertDimensions(s, 18, 24)
-
-	other.set(18, 24)
-	assert(s.equals(other), 's does not equal other. Got: ' + s.toString() + ' and ' + other.toString())
-
-	const surface = s.surface
-	const expected = 18 * 24
-	assert(surface == expected, 's surface is not ' + expected.toString() + '. Got: ' + surface.toString())
-
-	s.copyFrom(Size.Zero())
-	assertDimensions(s, 0, 0)
-
-	other.set(1.2, 2.3)
-	s.set(3.4, 4.5)
-	s.add(other)
-	assertDimensions(s, 4.6, 6.8)
-
-	s.set(3.4, 4.5)
-	other.set(1.2, 2.3)
-	s.subtract(other)
-	assertDimensions(s, 2.2, 2.2)
-
-	other.set(0, 0)
-	s.lerp(other, other.clone().set(100, 200), 0.345)
-	assertDimensions(s, 34.5, 69)
-
-	return true
-}
-
-function assertDimensions(s: Size, w: f64, h: f64): void {
-	assert(
-		s.width == w && s.height == h,
-		'Wrong dimensions. Expected {W: ' + w.toString() + ', H: ' + h.toString() + '}. Got: ' + s.toString()
-	)
 }
 
 export {testSize}


### PR DESCRIPTION
Added [as-pect](https://github.com/jtenner/as-pect), a test runner for AssemblyScript, and moved Size tests to `Size.spec.ts`