### PR TITLE
Change to use reference type instead of path

### DIFF
--- a/src/as/__tests__/as-pect.d.ts
+++ b/src/as/__tests__/as-pect.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="@as-pect/assembly/types/as-pect.d.ts" />
+/// <reference types="@as-pect/assembly/types/as-pect" />

--- a/src/as/__tests__/as-pect.d.ts
+++ b/src/as/__tests__/as-pect.d.ts
@@ -1,1 +1,1 @@
-/// <reference path="../../../node_modules/@as-pect/assembly/types/as-pect.d.ts" />
+/// <reference types="@as-pect/assembly/types/as-pect.d.ts" />


### PR DESCRIPTION
This way there isn't a relative path that assumes the use of node_modules.  For example, Yarn 2.0  uses PlugnPlay, which uses a different module resolution.